### PR TITLE
Allows to pass options to got

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ heads(urls)
   })
 ```
 
+### heads(urls, [options])
+
+##### urls
+
+Type: `string`, `array`
+
+The URL(s) to check.
+
+##### options
+
+See the [`got`](https://github.com/sindresorhus/got) options.
+
+
 Node-style callbacks are supported too:
 
 ```js

--- a/index.js
+++ b/index.js
@@ -1,18 +1,25 @@
 const async = require('async')
 const got = require('got')
 
-function heads(urls, callback) {
+function heads(urls, options, callback) {
+  options = options || {};
+
+  if (typeof options === 'function') {
+    callback = options;
+    options = undefined;
+  }
+
   if (typeof urls === 'string') {
     // just one URL
-    get(urls, callback)
+    get(options, urls, callback)
   } else {
     // an array of URLs
-    async.map(urls, get, callback)
+    async.map(urls, get.bind(null, options), callback)
   }
 }
 
-function get(url, callback) {
-  got.head(url)
+function get(options, url, callback) {
+  got.head(url, options)
     .then(response => {
       return callback(null, response.statusCode)
     })

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "pify": "^2.3.0"
   },
   "devDependencies": {
+    "sinon": "^2.1.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.0"
   },

--- a/test.js
+++ b/test.js
@@ -1,5 +1,7 @@
 const test = require('tape')
 const heads = require('.')
+const sinon = require('sinon')
+const got = require('got')
 const urls = [
   'https://google.com',
   'https://github.com',
@@ -8,7 +10,7 @@ const urls = [
 ]
 
 test('heads', function (t) {
-  t.plan(4)
+  t.plan(5)
 
   heads(urls, function(err, codes) {
     t.deepEqual(codes, [200, 200, 404, 200], 'returns an array of status codes')
@@ -21,5 +23,11 @@ test('heads', function (t) {
 
   heads(urls[0]).then(function(codes) {
     t.deepEqual(codes, 200, 'allows a single URL to be passed')
+  })
+
+  const headSpy = sinon.spy(got, 'head');
+  const options = { retries: 2 };
+  heads(urls[0], options).then(function(codes) {
+    t.deepEqual(headSpy.calledWithExactly(urls[0], options), true, 'allows got options to be passed')
   })
 })


### PR DESCRIPTION
In my service, I noticed that some request taking a long time to complete. After some investigation, it turns out that some urls passed to `heads` are running a very long time until the request time out kicks in. In `got` you can specify this `timeout`. This PR allows you to pass options all kind of options down to `got`.

```js
const urls = [
  'https://google.com',
  'http://wiki.fasterxml.com/JacksonHome',
  'https://github.com/nonexistent-url'
]
const options = {
    timeout: 1500,
    retries: 2
}

heads(urls, options, function(err, codes) {
  console.log(codes)
  // [ 200, undefined, 404 ]
})

```